### PR TITLE
[#52] Clean ns + fixed linting errors. Tests pass.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ pom.xml
 /lib/
 /target/
 .lein-deps-sum
+.portal
+.lsp/
+.clj-kondo/

--- a/src/clj/com/climate/claypoole/lazy.clj
+++ b/src/clj/com/climate/claypoole/lazy.clj
@@ -68,7 +68,7 @@
                                         ;; Use with-meta for priority
                                         ;; threadpools
                                         (with-meta #(apply f a)
-                                                   {:args a}))))
+                                          {:args a}))))
            ;; force buffer-size futures to start work in the pool
            (forceahead (or buffer-size (impl/get-pool-size pool) 0))
            ;; read the results from the futures
@@ -105,11 +105,11 @@
                     (let [p (promise)]
                       @(deliver p
                                 (cp/future-call
-                                  pool
+                                 pool
                                   ;; Use with-meta for priority threadpools
-                                  (with-meta #(try (apply f a)
-                                                   (finally (.put result-q @p)))
-                                             {:args a})))))]
+                                 (with-meta #(try (apply f a)
+                                                  (finally (.put result-q @p)))
+                                   {:args a})))))]
       (->> colls
            ;; make sure we're not chunking
            (map impl/unchunk)
@@ -121,7 +121,7 @@
            (forceahead buffer-size)
            ;; read the results from the futures in the queue
            (map (fn [_] (impl/deref-fixing-exceptions (.take result-q))))
-           (impl/seq-open #(if shutdown? (cp/shutdown pool)))))))
+           (impl/seq-open #(when shutdown? (cp/shutdown pool)))))))
 
 (defn upmap
   "Like pmap, but with results returned in the order they completed.


### PR DESCRIPTION

```
ieugen@daos-495:~/.../clojure/claypoole$ clj-kondo --lint src/

src/clj/com/climate/claypoole.clj:33:6: warning: Unused import CancellationException
src/clj/com/climate/claypoole.clj:37:6: warning: Unused import LinkedBlockingQueue
src/clj/com/climate/claypoole.clj:38:6: warning: Unused import ScheduledExecutorService
src/clj/com/climate/claypoole.clj:71:14: warning: unused binding daemon
src/clj/com/climate/claypoole.clj:71:21: warning: unused binding thread-priority
src/clj/com/climate/claypoole.clj:71:38: warning: unused binding pool-name
src/clj/com/climate/claypoole.clj:354:25: warning: unused binding i
src/clj/com/climate/claypoole/impl.clj:26:6: warning: Unused import List
src/clj/com/climate/claypoole/impl.clj:55:30: warning: unused binding e
src/clj/com/climate/claypoole/impl.clj:84:17: warning: unused binding timeout-ms
src/clj/com/climate/claypoole/impl.clj:84:28: warning: unused binding timeout-val
src/clj/com/climate/claypoole/impl.clj:89:15: warning: unused binding timeout
src/clj/com/climate/claypoole/impl.clj:89:23: warning: unused binding unit
src/clj/com/climate/claypoole/impl.clj:92:18: warning: unused binding interrupt?
src/clj/com/climate/claypoole/impl.clj:134:5: warning: Redundant let expression.
src/clj/com/climate/claypoole/lazy.clj:124:28: warning: Missing else branch.
linting took 162ms, errors: 0, warnings: 16
```
Signed-off-by: Eugen Stan <eugen.stan@netdava.com>