### PR TITLE
Fix CLJ-2619 equivalent bug in claypoole

### DIFF
--- a/src/clj/com/climate/claypoole/impl.clj
+++ b/src/clj/com/climate/claypoole/impl.clj
@@ -35,8 +35,14 @@
   (let [frame (clojure.lang.Var/cloneThreadBindingFrame)]
     (with-meta
       (fn []
-        (clojure.lang.Var/resetThreadBindingFrame frame)
-        (f))
+        (let [frame-before (clojure.lang.Var/getThreadBindingFrame)]
+          (clojure.lang.Var/resetThreadBindingFrame frame)
+          (try
+            (f)
+            (finally
+              ;; This does not matter for correctness, but prevents leaking
+              ;; data in binding frames in thread locals.
+              (clojure.lang.Var/resetThreadBindingFrame frame-before)))))
       (meta f))))
 
 (defn deref-future


### PR DESCRIPTION
There is a memory "leak" for thread futures because the thread bindings are kept around after the future fn runs. We reset the bindings again by the time we run the next future, so it's not a correctness issue. Unfortunately until that next future (which might not happen for a while with large thread pools) we're keeping all the bindings saved for no good reason.