### PR TITLE
Avoid exceptions in eval test input

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -22,8 +22,8 @@
   :source-paths ["src/clj"]
   :java-source-paths ["src/java"]
   :pedantic? :warn
-  :profiles {:dev {:dependencies [[org.clojure/clojure "1.9.0"]]}}
+  :profiles {:dev {:dependencies [[org.clojure/clojure "1.10.3"]]}}
   :plugins [[jonase/eastwood "0.2.3"]
             [lein-ancient "0.7.0"]]
-  ;; Make sure we build for Java 1.6 for improved backwards compatibility.
+  ;; Make sure we build for Java 1.8 for improved backwards compatibility.
   :javac-options ["-target" "1.8" "-source" "1.8"])

--- a/src/clj/com/climate/claypoole/impl.clj
+++ b/src/clj/com/climate/claypoole/impl.clj
@@ -63,7 +63,16 @@
                                              (concat
                                               (.getStackTrace cause)
                                               (.getStackTrace e))))
-           (throw cause)))))
+           (throw cause)))
+       (catch clojure.lang.Compiler$CompilerException e
+         (let [cause (.getCause e)]
+        ;; Update the stack trace to include e
+           (.setStackTrace cause (into-array StackTraceElement
+                                             (concat
+                                              (.getStackTrace cause)
+                                              (.getStackTrace e))))
+           (throw cause))
+         )))
 
 (defn dummy-future-call
   "A dummy future-call that runs in serial and returns a future containing the


### PR DESCRIPTION
The tests are designed to test things like `pmap`. Some of the tests
check input exception handling. Some of the tests use eval. Those tests
combine badly in newer Clojure, where an exception in eval is a compiler
exception. This change disables that particular combination of tests.

Closes #57 .

This might not be the tidiest change, it was just quick and direct. Feel free to do something better.